### PR TITLE
fix: wrong view count

### DIFF
--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -41,7 +41,7 @@ export default async function PostPage({ params }: Props) {
 
   return (
     <div className="bg-zinc-50 min-h-screen">
-      <Header project={project} views={views} />
+      <Header project={project} views={views + 1} />
       <ReportView slug={project.slug} />
 
       <article className="px-4 py-12 mx-auto prose prose-zinc prose-quoteless">


### PR DESCRIPTION
Let me explain: If we create a new .mdx file, then the first person who comes to [slug].page will see the number 0, although it should be 1. This is due to the fact that Redis receives the request and only then sends it.

![image](https://github.com/chronark/chronark.com/assets/122895078/8d81c08b-67df-4296-b0b5-336f911a55fa)
We go to the page
![image](https://github.com/chronark/chronark.com/assets/122895078/b15e095f-9935-4623-8711-46a9b4d1f1d2)
And we see that 0 is displayed although there is already 1 person in Redis.